### PR TITLE
Fixed paths to be compatible with the new moonraker version

### DIFF
--- a/scripts/etc_default_klipper
+++ b/scripts/etc_default_klipper
@@ -1,8 +1,8 @@
 # Configuration for /etc/init.d/klipper
 
 KLIPPY_USER=android
-KLIPPY_CONFIG=/home/$KLIPPY_USER/klipper_config/printer.cfg
-KLIPPY_LOG=/home/$KLIPPY_USER/klipper_logs/klippy.log
+KLIPPY_CONFIG=/home/$KLIPPY_USER/printer_data/config/printer.cfg
+KLIPPY_LOG=/home/$KLIPPY_USER/printer_data/logs/klippy.log
 KLIPPY_SOCKET=/tmp/klippy_uds
 KLIPPY_PRINTER=/tmp/printer
 KLIPPY_EXEC=/home/$KLIPPY_USER/klippy-env/bin/python

--- a/scripts/etc_default_moonraker
+++ b/scripts/etc_default_moonraker
@@ -1,8 +1,8 @@
 # Configuration for /etc/init.d/moonraker
 
 MOONRAKER_USER=android
-MOONRAKER_CONFIG=/home/$MOONRAKER_USER/klipper_config/moonraker.conf
-MOONRAKER_LOG=/home/$MOONRAKER_USER/klipper_logs/moonraker.log
+MOONRAKER_CONFIG=/home/$MOONRAKER_USER/printer_data/config/moonraker.conf
+MOONRAKER_LOG=/home/$MOONRAKER_USER/printer_data/logs/moonraker.log
 MOONRAKER_SOCKET=/tmp/moonraker_uds
 MOONRAKER_PRINTER=/tmp/printer
 MOONRAKER_EXEC=/home/$MOONRAKER_USER/moonraker-env/bin/python

--- a/scripts/usr_local_bin_xterm
+++ b/scripts/usr_local_bin_xterm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 KLIPPERSCREEN_USER=android
-KLIPPERSCREEN_CONFIG=/home/$KLIPPERSCREEN_USER/klipper_config/KlipperScreen.conf
-KLIPPERSCREEN_LOG=/home/$KLIPPERSCREEN_USER/klipper_logs/KlipperScreen.log
+KLIPPERSCREEN_CONFIG=/home/$KLIPPERSCREEN_USER/printer_data/config/KlipperScreen.conf
+KLIPPERSCREEN_LOG=/home/$KLIPPERSCREEN_USER/printer_data/logs/KlipperScreen.log
 
 /home/$KLIPPERSCREEN_USER/.KlipperScreen-env/bin/python /home/$KLIPPERSCREEN_USER/KlipperScreen/screen.py -c $KLIPPERSCREEN_CONFIG -l $KLIPPERSCREEN_LOG


### PR DESCRIPTION
The latest moonraker update expects the config, log and other paths to be in `~/printer_data/...` now: https://moonraker.readthedocs.io/en/latest/installation/#data-folder-structure

Old installations usually sym link the new paths to the old paths which means that these changes should still work for everyone.