### PR TITLE
Add support form mobileraker and crowsnest and fix klippy and moonraker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
     # or 
     sudo chmod 777 /home/android/octo4a/serialpipe
     ```
-- Install the init and xterm scripts from this gist:  
+- Install the init and xterm scripts from this gist:
   ```bash
   sudo wget -O /etc/default/klipper https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_default_klipper
   sudo wget -O /etc/init.d/klipper https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_klipper
@@ -98,7 +98,41 @@ Logs can be found in `/home/android/klipper_logs`.
 
 ## Telegram Bot
 You can find the instructions how to setup the Telegram Bot [here](https://github.com/d4rk50ul1/klipper-on-android/blob/main/telegram_instructions.md)
+## Mobileraker
+You can install mobileraker by following these steps:
+  1. Go to kiauh and install mobileraker
+     ```bash 
+     kiauh/kiauh.sh
+     ```
+  2. Install the init script for mobileraker from this git:
+     ```bash
+     sudo wget -O /etc/default/mobileraker https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_default_mobileraker
+     sudo wget -O /etc/init.d/mobileraker https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_mobileraker
 
+     sudo chmod +x /etc/init.d/mobileraker 
+    
+     sudo update-rc.d mobileraker defaults
+     ```
+## Crowsnest
+If you want to use a webcam to monitor your prints you have to install crowsnest.
+  1. Go to kiauh and install crowsnest
+     ```bash 
+     kiauh/kiauh.sh
+     ```
+  2. Install the init script for crowsnest from this git:
+     ```bash
+     sudo wget -O /etc/default/crowsnest https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_default_crowsnest
+     sudo wget -O /etc/init.d/crowsnest https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_crowsnest
+
+     sudo chmod +x /etc/init.d/crowsnest 
+    
+     sudo update-rc.d crowsnest defaults
+     ```
+The crowsnest service will fail to start even if you have a webcam connected because it wasn't made for this use case. You need to delete [this](https://github.com/mainsail-crew/crowsnest/blob/master/libs/logging.sh#L98) line from ```/home/${user}/crowsnest/libs/logging.sh```. 
+
+When you connect your webcam it will most probably appear as a ```/dev/videoX``` device (mine is ```/dev/video3```). When you find your webcam you will need to ```sudo chmod 777 /dev/videoX``` it and edit the crowsnest.conf file that is located in ```/home/${user}/printer_data/config/``` to point to your camera.
+
+After you completed all the steps you need to start the service using ```sudo service crowsnest start``` and see if it works. If it doesent't look at the log that is located in ```/home/${user}/printer_data/log/crowsnest.log```. There will be some errors that it can't find any usable devices or cameras. You can ignore these errors, they appear because of our little workaround form above.
 ## Troubleshooting (ongoing section based on comments)
 - There might be the case that when accessing Mainsail through Browser, you get an error message and no connection to moonraker: mainsail Permission denied while connecting to upstream in `klipper_logs/mainsail_error.log`. To fix this you must change the file `/etc/nginx/nginx.conf`, change `user www-data;` to `user android;` 
 - If anyone is having network issues in the container as a non root user after a few minutes, you need to disable deep sleep/idle. You can do that by using this command in a shell (termux or adb doesn't matter): `dumpsys deviceidle disable`. You may also need this app: [Wake Lock - CPU Awake] (https://play.google.com/store/apps/details?id=com.dambara.wakelocker)

--- a/scripts/etc_default_crowsnest
+++ b/scripts/etc_default_crowsnest
@@ -1,0 +1,5 @@
+# Configuration for /etc/init.d/crowsnest
+
+CROWSNEST_USER=android
+CROWSNEST_EXEC=/usr/local/bin/crowsnest
+CROWSNEST_ARGS="-c /home/$CROWSNEST_USER/printer_data/config/crowsnest.conf"

--- a/scripts/etc_default_klipper
+++ b/scripts/etc_default_klipper
@@ -3,7 +3,8 @@
 KLIPPY_USER=android
 KLIPPY_CONFIG=/home/$KLIPPY_USER/printer_data/config/printer.cfg
 KLIPPY_LOG=/home/$KLIPPY_USER/printer_data/logs/klippy.log
-KLIPPY_SOCKET=/tmp/klippy_uds
+KLIPPY_SOCKET=/home/$KLIPPY_USER/printer_data/comms/klippy.sock
+KLIPPY_SERIAL=/home/$KLIPPY_USER/printer_data/comms/klippy.serial
 KLIPPY_PRINTER=/tmp/printer
 KLIPPY_EXEC=/home/$KLIPPY_USER/klippy-env/bin/python
-KLIPPY_ARGS="/home/$KLIPPY_USER/klipper/klippy/klippy.py $KLIPPY_CONFIG -l $KLIPPY_LOG -a $KLIPPY_SOCKET"
+KLIPPY_ARGS="/home/$KLIPPY_USER/klipper/klippy/klippy.py $KLIPPY_CONFIG -I $KLIPPY_SERIAL -l $KLIPPY_LOG -a $KLIPPY_SOCKET"

--- a/scripts/etc_default_mobileraker
+++ b/scripts/etc_default_mobileraker
@@ -1,4 +1,4 @@
-# Configuration for /etc/default/mobileraker
+# Configuration for /etc/init.d/mobileraker
 
 MOBILERAKER_USER=android
 MOBILERAKER_EXEC=/home/$MOBILERAKER_USER/mobileraker-env/bin/python

--- a/scripts/etc_default_mobileraker
+++ b/scripts/etc_default_mobileraker
@@ -1,0 +1,5 @@
+# Configuration for /etc/default/mobileraker
+
+MOBILERAKER_USER=android
+MOBILERAKER_EXEC=/home/$MOBILERAKER_USER/mobileraker-env/bin/python
+MOBILERAKER_ARGS="/home/$MOBILERAKER_USER/mobileraker_companion/mobileraker.py"

--- a/scripts/etc_default_moonraker
+++ b/scripts/etc_default_moonraker
@@ -1,9 +1,8 @@
 # Configuration for /etc/init.d/moonraker
 
 MOONRAKER_USER=android
-MOONRAKER_CONFIG=/home/$MOONRAKER_USER/printer_data/config/moonraker.conf
-MOONRAKER_LOG=/home/$MOONRAKER_USER/printer_data/logs/moonraker.log
+MOONRAKER_DIRECTORY=/home/$MOONRAKER_USER/printer_data/
 MOONRAKER_SOCKET=/tmp/moonraker_uds
 MOONRAKER_PRINTER=/tmp/printer
 MOONRAKER_EXEC=/home/$MOONRAKER_USER/moonraker-env/bin/python
-MOONRAKER_ARGS="/home/$MOONRAKER_USER/moonraker/moonraker/moonraker.py -c $MOONRAKER_CONFIG -l $MOONRAKER_LOG"
+MOONRAKER_ARGS="/home/$MOONRAKER_USER/moonraker/moonraker/moonraker.py -d $MOONRAKER_DIRECTORY"

--- a/scripts/etc_init.d_crowsnest
+++ b/scripts/etc_init.d_crowsnest
@@ -1,0 +1,54 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          crowsnest
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: crowsnest - Multi Webcam/Streamer Control Deamon
+# Description:       Start the crowsnest daemon.
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+DESC="crowsnest - Multi Webcam/Streamer Control Deamon"
+NAME="crowsnest"
+DEFAULTS_FILE=/etc/default/crowsnest
+PIDFILE=/var/run/crowsnest.pid
+
+# Read configuration variable file if it is present
+[ -r $DEFAULTS_FILE ] && . $DEFAULTS_FILE
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+# Case statement for the command
+case "$1" in
+start)  log_daemon_msg "Starting" $NAME
+        start-stop-daemon --start --quiet --exec $CROWSNEST_EXEC \
+                          --background --pidfile $PIDFILE --make-pidfile \
+                          --chuid $CROWSNEST_USER --user $CROWSNEST_USER \
+                          -- $CROWSNEST_ARGS
+        log_end_msg $?
+        ;;
+stop)   log_daemon_msg "Stopping" $NAME
+        killproc -p $PIDFILE $CROWSNEST_EXEC
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && [ -e "$PIDFILE" ] && rm -f $PIDFILE
+        log_end_msg $RETVAL
+        ;;
+restart) log_daemon_msg "Restarting" $NAME
+        $0 stop
+        $0 start
+        ;;
+reload|force-reload)
+        log_daemon_msg "Reloading configuration not supported" $NAME
+        log_end_msg 1
+        ;;
+status)
+        status_of_proc -p $PIDFILE $CROWSNEST_EXEC $NAME && exit 0 || exit $?
+        ;;
+*)      log_action_msg "Usage: /etc/init.d/crowsnest {start|stop|status|restart|reload|force-reload}"
+        exit 2
+        ;;
+esac
+exit 0

--- a/scripts/etc_init.d_mobileraker
+++ b/scripts/etc_init.d_mobileraker
@@ -1,12 +1,4 @@
-  GNU nano 5.4                                                        /etc/init.d/mobileraker                                                                 
 #!/bin/bash
-#
-# mobileraker: Companion app to enable push notifications on mobileraker
-#
-# chkconfig: 2345 20 80
-# description: Companion app to enable push notifications on mobileraker
-# processname: mobileraker
-
 ### BEGIN INIT INFO
 # Provides:          mobileraker
 # Required-Start:    $network $local_fs $remote_fs
@@ -18,6 +10,7 @@
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME="mobileraker"
 DEFAULTS_FILE=/etc/default/mobileraker
 PIDFILE=/var/run/mobileraker.pid
 
@@ -27,28 +20,32 @@ PIDFILE=/var/run/mobileraker.pid
 [ -r $DEFAULTS_FILE ] && . $DEFAULTS_FILE
 
 case "$1" in
-  start)
-    log_daemon_msg "Starting mobileraker"
-    start-stop-daemon --start --background --make-pidfile --pidfile $PIDFILE --chuid $MOBILERAKER_USER --exec $MOBILERAKER_EXEC -- $MOBILERAKER_ARGS
-    log_end_msg $?
-    ;;
-  stop)
-    log_daemon_msg "Stopping mobileraker"
-    start-stop-daemon --stop --pidfile $PIDFILE
-    log_end_msg $?
-    ;;
-  restart)
-    $0 stop
-    sleep 1
-    $0 start
-    ;;
-  status)
-    status_of_proc -p $PIDFILE $MOBILERAKER_EXEC "mobileraker" && exit 0 || exit $?
-    ;;
-  *)
-    echo "Usage: $0 {start|stop|restart|status}"
-    exit 1
-    ;;
+start)  log_daemon_msg "Starting" $NAME
+        start-stop-daemon --start --quiet --exec $MOBILERAKER_EXEC \
+                          --background --pidfile $PIDFILE --make-pidfile \
+                          --chuid $MOBILERAKER_USER --user $MOBILERAKER_USER\
+                          -- $MOBILERAKER_ARGS
+        log_end_msg $?
+        ;;
+stop)   log_daemon_msg "Stopping" $NAME
+        killproc -p $PIDFILE $MOBILERAKER_EXEC
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && [ -e "$PIDFILE" ] && rm -f $PIDFILE
+        log_end_msg $RETVAL
+        ;;
+restart) log_daemon_msg "Restarting" $NAME
+        $0 stop
+        $0 start
+        ;;
+reload|force-reload)
+        log_daemon_msg "Reloading configuration not supported" $NAME
+        log_end_msg 1
+        ;;
+status)
+        status_of_proc -p $PIDFILE $MOBILERAKER_EXEC $NAME && exit 0 || exit $?
+        ;;
+*)      log_action_msg "Usage: /etc/init.d/mobileraker {start|stop|status|restart|reload|force-reload}"
+        exit 2
+        ;;
 esac
-
 exit 0

--- a/scripts/etc_init.d_mobileraker
+++ b/scripts/etc_init.d_mobileraker
@@ -1,0 +1,54 @@
+  GNU nano 5.4                                                        /etc/init.d/mobileraker                                                                 
+#!/bin/bash
+#
+# mobileraker: Companion app to enable push notifications on mobileraker
+#
+# chkconfig: 2345 20 80
+# description: Companion app to enable push notifications on mobileraker
+# processname: mobileraker
+
+### BEGIN INIT INFO
+# Provides:          mobileraker
+# Required-Start:    $network $local_fs $remote_fs
+# Required-Stop:     $network $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Companion app to enable push notifications on mobileraker
+# Description:       Companion app to enable push notifications on mobileraker
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DEFAULTS_FILE=/etc/default/mobileraker
+PIDFILE=/var/run/mobileraker.pid
+
+. /lib/lsb/init-functions
+
+# Read defaults file
+[ -r $DEFAULTS_FILE ] && . $DEFAULTS_FILE
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting mobileraker"
+    start-stop-daemon --start --background --make-pidfile --pidfile $PIDFILE --chuid $MOBILERAKER_USER --exec $MOBILERAKER_EXEC -- $MOBILERAKER_ARGS
+    log_end_msg $?
+    ;;
+  stop)
+    log_daemon_msg "Stopping mobileraker"
+    start-stop-daemon --stop --pidfile $PIDFILE
+    log_end_msg $?
+    ;;
+  restart)
+    $0 stop
+    sleep 1
+    $0 start
+    ;;
+  status)
+    status_of_proc -p $PIDFILE $MOBILERAKER_EXEC "mobileraker" && exit 0 || exit $?
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
I added support for mobileraker_companion and crowsnest. I also edited the etc_default_klipper and etc_default_moonraker files to point to the correct locations and have the same launch options as the original .env files.