### PR TITLE
update init scripts and add klipperscreen scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,26 @@
     sudo chmod 777 /dev/ttyUSB0
     # or 
     sudo chmod 777 /home/android/octo4a/serialpipe
+    sudo chown -R android:android /home/android/octo4a
     ```
+- Make sure the moonraker config is correct `/home/android/printer_data/config/moonraker.conf`:
+  - set the correct socket path: `klippy_uds_address: /home/android/printer_data/comms/klippy.sock`
+  - change the provider under the `[machine]` section because we're using SysVinit: `provider: none`
 - Install the init and xterm scripts from this gist:  
   ```bash
   sudo wget -O /etc/default/klipper https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_default_klipper
   sudo wget -O /etc/init.d/klipper https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_klipper
+  sudo wget -O /etc/init.d/klipperscreen https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_klipperscreen
   sudo wget -O /etc/default/moonraker https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_default_moonraker
   sudo wget -O /etc/init.d/moonraker https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/etc_init.d_moonraker
   sudo wget -O /usr/local/bin/xterm https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/usr_local_bin_xterm
-  
+  sudo wget -O /home/android/KlipperScreen/scripts/launch_KlipperScreen.sh https://raw.githubusercontent.com/d4rk50ul1/klipper-on-android/main/scripts/home_android_KlipperScreen_scripts_launch_Klipperscreen.sh
+
   sudo chmod +x /etc/init.d/klipper 
+  sudo chmod +x /etc/init.d/klipperscreen
   sudo chmod +x /etc/init.d/moonraker 
   sudo chmod +x /usr/local/bin/xterm
+  sudo chmod +x /home/android/KlipperScreen/scripts/launch_KlipperScreen.sh
   
   sudo update-rc.d klipper defaults
   sudo update-rc.d moonraker defaults

--- a/scripts/etc_default_klipper
+++ b/scripts/etc_default_klipper
@@ -3,7 +3,7 @@
 KLIPPY_USER=android
 KLIPPY_CONFIG=/home/$KLIPPY_USER/printer_data/config/printer.cfg
 KLIPPY_LOG=/home/$KLIPPY_USER/printer_data/logs/klippy.log
-KLIPPY_SOCKET=/tmp/klippy_uds
+KLIPPY_SOCKET=/home/android/printer_data/comms/klippy.sock
 KLIPPY_PRINTER=/tmp/printer
 KLIPPY_EXEC=/home/$KLIPPY_USER/klippy-env/bin/python
 KLIPPY_ARGS="/home/$KLIPPY_USER/klipper/klippy/klippy.py $KLIPPY_CONFIG -l $KLIPPY_LOG -a $KLIPPY_SOCKET"

--- a/scripts/etc_default_moonraker
+++ b/scripts/etc_default_moonraker
@@ -3,7 +3,7 @@
 MOONRAKER_USER=android
 MOONRAKER_CONFIG=/home/$MOONRAKER_USER/printer_data/config/moonraker.conf
 MOONRAKER_LOG=/home/$MOONRAKER_USER/printer_data/logs/moonraker.log
-MOONRAKER_SOCKET=/tmp/moonraker_uds
+MOONRAKER_SOCKET=/home/android/printer_data/comms/moonraker.sock
 MOONRAKER_PRINTER=/tmp/printer
 MOONRAKER_EXEC=/home/$MOONRAKER_USER/moonraker-env/bin/python
 MOONRAKER_ARGS="/home/$MOONRAKER_USER/moonraker/moonraker/moonraker.py -c $MOONRAKER_CONFIG -l $MOONRAKER_LOG"

--- a/scripts/etc_init.d_klipperscreen
+++ b/scripts/etc_init.d_klipperscreen
@@ -1,0 +1,53 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          klipperscreen
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start KlipperScreen service
+# Description:       This file starts and stops KlipperScreen.
+### END INIT INFO
+
+NAME=klipperscreen
+USER=android
+KS_DIR="/home/android/KlipperScreen"
+KS_EXEC="$KS_DIR/scripts/KlipperScreen-start.sh"
+PIDFILE="/var/run/$NAME.pid"
+
+. /lib/lsb/init-functions
+
+start() {
+    log_daemon_msg "Starting KlipperScreen service"
+    start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --chuid $USER --exec $KS_EXEC \
+    >> /home/android/printer_data/logs/klipperscreen.log 2>&1 # 2>&1 means redirect stderr to stdout
+    log_end_msg $?
+}
+
+stop() {
+    log_daemon_msg "Stopping KlipperScreen service"
+    start-stop-daemon --stop --quiet --pidfile $PIDFILE --retry 5
+    log_end_msg $?
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload|force-reload)
+        stop
+        start
+        ;;
+    status)
+        status_of_proc "$KS_EXEC" "$NAME" && exit 0 || exit $?
+        ;;
+    *)
+        echo "Usage: /etc/init.d/klipperscreen {start|stop|restart|status}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/scripts/home_android_KlipperScreen_scripts_launch_KlipperScreen.sh
+++ b/scripts/home_android_KlipperScreen_scripts_launch_KlipperScreen.sh
@@ -1,0 +1,3 @@
+echo "setting DISPLAY=:0 and running xterm to start klipperscreen"
+export DISPLAY=:0
+xterm


### PR DESCRIPTION
I just used this guide to install this on my ender 3 v3 se and a lenovo tablet ([blog](https://interesting-corner.nl/blog/ender3v3se-klipper)), but while doing so I ran into some problems. This PR fixes those and updates the scripts to be more recent. What I added:
- sysvinit script for klipperscreen
- update sockets for klipper and moonraker
- update moonraker.conf
- add launch script for klipperscreen that properly sets the display